### PR TITLE
Fix negative lexing tests

### DIFF
--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -23,11 +23,14 @@ def _test_single_token(token: str, lexeme_type: Type):
 
 def _test_bad_single_token(token: str, intended_type: Type):
     try:
-        _test_single_token(token, intended_type)
-    except AssertionError:
-        assert True
+        lexemes = vl.Lexer.lex_token(token)
     except vl.LexerError:
         assert True
+    else:
+        if len(lexemes) == 1:
+            assert lexemes[0] != intended_type(token)
+        else:
+            assert True
 
 
 # COMMA
@@ -89,7 +92,7 @@ def test_class(token: str):
 
 
 @pytest.mark.parametrize('token', [
-    'a-class', 'a_class', 'aA', '9', '9a', '!?',
+    'a-class', 'a_class', 'aA', 'A-', 'A-?', '9', '9a', '!?',
 ])
 def test_bad_class(token: str):
     _test_bad_single_token(token, vl.Class)

--- a/viper/lexer.py
+++ b/viper/lexer.py
@@ -27,8 +27,8 @@ RE_NUMBER = re.compile(r'(?:\d+)'                           # 42
                        r'(?:\d+[eE][+-]?\d+)'               # 42e3
                        r'|'
                        r'(?:\d+\.\d*(?:[eE][+-]?\d+)?)')    # 42.7e2 | 42.e9 | 42. | 42.3e-8
-RE_NAME = re.compile(r'_+|(?:_*[a-z][_a-zA-Z0-9]*(?:-[_a-zA-Z0-9]*)*[!@$%^&*?]?)')
-RE_CLASS = re.compile(r'[A-Z][-_a-zA-Z0-9]*')
+RE_NAME = re.compile(r'_+|(?:_*[a-z][_a-zA-Z0-9]*(?:-[_a-zA-Z0-9]+)*[!@$%^&*?]?)')
+RE_CLASS = re.compile(r'[A-Z][_a-zA-Z0-9]*(?:-[_a-zA-Z0-9]+)*')
 RE_OPERATOR = re.compile(r'[!@$%^&*()\-=+|:/?<>\[\]{}~.]+')
 
 


### PR DESCRIPTION
Now properly forbids some constructs such as `Name('a-')` and `Class('A-')`.